### PR TITLE
feat: Add user records functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.4.0",
+        "lodash.debounce": "^4.0.8",
         "pinia": "^2.0.36",
         "primeflex": "^3.3.1",
         "primeicons": "^6.0.1",
@@ -3433,6 +3434,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -7305,6 +7311,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "axios": "^1.4.0",
+    "lodash.debounce": "^4.0.8",
     "pinia": "^2.0.36",
     "primeflex": "^3.3.1",
     "primeicons": "^6.0.1",

--- a/src/interfaces/Record.ts
+++ b/src/interfaces/Record.ts
@@ -1,0 +1,26 @@
+export interface Record {
+  _id: string
+  operation_id: string
+  user_id: string
+  amount: string
+  user_balance: string
+  operation_response: string
+  is_deleted: boolean
+  created_at: Date
+  updated_at: Date
+}
+export interface FormatRecord {
+  _id: string
+  operation_id: string
+  user_id: string
+  amount: string
+  user_balance: string
+  operation_response: string
+  is_deleted: boolean
+  created_at: String
+  updated_at: Date
+}
+export interface Records {
+  records: Record[]
+  total_records: number
+}

--- a/src/services/RecordsService.ts
+++ b/src/services/RecordsService.ts
@@ -6,11 +6,13 @@ export const getRecords = async (
   user_id: string,
   page: number = 0,
   limit: number = 5,
+  sortField: string = '_id',
+  sortOrder: number = 1 ,
   payload: any
 ): Promise<Records> => {
   try {
     const response: AxiosResponse<Records> = await useApiPrivate().get(
-      `/api/records/${user_id}?page=${page}&limit=${limit}`,
+      `/api/records/${user_id}?page=${page}&limit=${limit}&sortField=${sortField}&sortOrder=${sortOrder}`,
       payload
     )
     return response.data

--- a/src/services/RecordsService.ts
+++ b/src/services/RecordsService.ts
@@ -1,0 +1,31 @@
+import { useApiPrivate } from '@/composables/useApi'
+import { Records } from '@/interfaces/Record'
+import { AxiosResponse } from 'axios'
+
+export const getRecords = async (
+  user_id: string,
+  page: number = 0,
+  limit: number = 5,
+  payload: any
+): Promise<Records> => {
+  try {
+    const response: AxiosResponse<Records> = await useApiPrivate().get(
+      `/api/records/${user_id}?page=${page}&limit=${limit}`,
+      payload
+    )
+    return response.data
+  } catch (error: Error | any) {
+    throw error.response.data
+  }
+}
+export const deleteRecord = async (record_id: string, payload: any): Promise<any> => {
+  try {
+    const response: AxiosResponse<any> = await useApiPrivate().post(
+      `/api/records/record/${record_id}`,
+      payload
+    )
+    return response.data
+  } catch (error: Error | any) {
+    throw error.response.data
+  }
+}

--- a/src/services/RecordsService.ts
+++ b/src/services/RecordsService.ts
@@ -8,11 +8,12 @@ export const getRecords = async (
   limit: number = 5,
   sortField: string = '_id',
   sortOrder: number = 1 ,
+  searchText: string = '',
   payload: any
 ): Promise<Records> => {
   try {
     const response: AxiosResponse<Records> = await useApiPrivate().get(
-      `/api/records/${user_id}?page=${page}&limit=${limit}&sortField=${sortField}&sortOrder=${sortOrder}`,
+      `/api/records/${user_id}?page=${page}&limit=${limit}&sortField=${sortField}&sortOrder=${sortOrder}&searchText=${searchText}`,
       payload
     )
     return response.data

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import {useApi, useApiPrivate} from '@/composables/useApi'
 
 export interface User {
+  id: string
   username: string
   user_balance: string
 }

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,4 @@
+export const formatDate = (date: Date): string => {
+  const formattedDate = new Date(date)
+  return formattedDate.toLocaleString('en-US')
+}

--- a/src/views/UserRecords.vue
+++ b/src/views/UserRecords.vue
@@ -116,6 +116,7 @@ const handleSearch = (): void => {
 }
 const clearSearchText = (): void => {
   searchText.value = ''
+  selectedRecord.value = null
   getRecordsService()
 }
 </script>
@@ -191,6 +192,7 @@ const clearSearchText = (): void => {
     :style="{ width: '450px' }"
     header="Confirm"
     :modal="true"
+    @hide="hideDeletedDialog"
   >
     <div class="confirmation-content">
       <i class="pi pi-exclamation-triangle mr-3" style="font-size: 2rem" />

--- a/src/views/UserRecords.vue
+++ b/src/views/UserRecords.vue
@@ -1,7 +1,162 @@
-<template>
-<h1>User Records</h1>
-</template>
-
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import DataTable from 'primevue/datatable'
+import Column from 'primevue/column'
+import InputText from 'primevue/inputtext'
+import Button from 'primevue/button'
+import Dialog from 'primevue/dialog'
+import Toast from 'primevue/toast'
+import { useToast } from 'primevue/usetoast'
+import { deleteRecord, getRecords } from '@/services/RecordsService'
+import { formatDate } from '@/utils/formatDate'
+import { FormatRecord, Record } from '@/interfaces/Record'
+import { useAuthStore } from '@/stores/auth'
+import { computed } from 'vue'
 
+const toast = useToast()
+const records = ref<FormatRecord[]>([])
+const selectedRecord = ref<Record | null>(null)
+const deleteRecordDialog = ref<boolean>(false)
+
+const page = ref<number>(0)
+const limit = ref<number>(5)
+const rowsPerPageOptions = ref<number[]>([5, 10, 15, 20])
+const totalRecords = ref<number>(20)
+const loading = ref<boolean>(false)
+const authStore = useAuthStore()
+
+const user = computed(() => {
+  return authStore.userDetail
+})
+const getRecordsService = async (): Promise<void> => {
+  try {
+    loading.value = true
+    const res = await getRecords(user.value.id, page.value, limit.value, {})
+    const formattedRecords: FormatRecord[] = res.records.map((record: Record) => {
+      return {
+        ...record,
+        created_at: formatDate(record.created_at)
+      }
+    })
+    records.value = formattedRecords
+    totalRecords.value = res.total_records
+    loading.value = false
+  } catch (error) {
+    console.log(error)
+  }
+}
+
+onMounted(async (): Promise<void> => {
+  await getRecordsService()
+})
+
+const confirmDeleteSelected = (): void => {
+  deleteRecordDialog.value = true
+}
+const hideDeletedDialog = (): void => {
+  deleteRecordDialog.value = false
+  selectedRecord.value = null
+}
+
+const deleteRecordApi = async (): Promise<void> => {
+  try {
+    await deleteRecord(selectedRecord.value!._id, {})
+    await getRecordsService()
+    toast.add({
+      severity: 'success',
+      summary: 'Success Message',
+      detail: 'Record deleted successfully',
+      life: 3000
+    })
+  } catch (error) {
+    console.log(error)
+    toast.add({
+      severity: 'error',
+      summary: 'Error Message',
+      detail: 'This Record can not be deleted',
+      life: 3000
+    })
+  }
+  deleteRecordDialog.value = false
+  selectedRecord.value = null
+}
+const handlePageChange = async (event): Promise<void> => {
+  if (page.value !== event.page || limit.value !== event.rows) {
+    page.value = event.page
+    limit.value = event.rows
+    await getRecordsService()
+  }
+}
 </script>
+
+<template>
+  <h1 class="text-center">User Records</h1>
+  <Toast position="top-center" />
+  <div class="card mx-4">
+    <DataTable
+      v-model:selection="selectedRecord"
+      paginator
+      lazy
+      :loading="loading"
+      :value="records"
+      :totalRecords="totalRecords"
+      :rows="limit"
+      :rowsPerPageOptions="rowsPerPageOptions"
+      tableStyle="min-width: 50rem"
+      dataKey="_id"
+      :onPage="handlePageChange"
+    >
+      <template #header>
+        <div class="flex justify-content-between">
+          <div>
+            <Button type="button" icon="pi pi-filter-slash" label="Clear" outlined />
+            <Button
+              label="Delete"
+              icon="pi pi-trash"
+              severity="danger"
+              :disabled="!selectedRecord"
+              class="mx-4"
+              @click="confirmDeleteSelected"
+            />
+          </div>
+          <span class="p-input-icon-left">
+            <i class="pi pi-search" />
+            <InputText placeholder="Keyword Search" />
+          </span>
+        </div>
+      </template>
+      <Column selectionMode="single" headerStyle="width: 3rem" class="text-center"></Column>
+      <Column field="_id" header="Id" sortable style="width: 5%"></Column>
+      <Column field="operation_id" header="Operation Id" sortable style="width: 15%"></Column>
+      <Column field="user_id" header="User Id" sortable style="width: 15%"></Column>
+      <Column field="amount" header="Amount" sortable style="width: 10%"></Column>
+      <Column field="user_balance" header="User Balance" sortable style="width: 10%"></Column>
+      <Column
+        field="operation_response"
+        header="Operation Response"
+        sortable
+        style="width: 15%"
+      ></Column>
+      <Column field="created_at" header="Created At" sortable style="width: 15%"></Column>
+    </DataTable>
+  </div>
+  <Dialog
+    v-model:visible="deleteRecordDialog"
+    :style="{ width: '450px' }"
+    header="Confirm"
+    :modal="true"
+  >
+    <div class="confirmation-content">
+      <i class="pi pi-exclamation-triangle mr-3" style="font-size: 2rem" />
+      <span v-if="selectedRecord">
+        Are you sure you want to delete operation
+        <b>{{ selectedRecord._id }}</b
+        >?
+      </span>
+    </div>
+    <template #footer>
+      <Button label="No" icon="pi pi-times" text @click="hideDeletedDialog" />
+      <Button label="Yes" icon="pi pi-check" text @click="deleteRecordApi" />
+    </template>
+  </Dialog>
+</template>

--- a/src/views/UserRecords.vue
+++ b/src/views/UserRecords.vue
@@ -20,8 +20,10 @@ const deleteRecordDialog = ref<boolean>(false)
 
 const page = ref<number>(0)
 const limit = ref<number>(5)
+const sortField = ref<string>('');
+const sortOrder = ref<number>(1);
 const rowsPerPageOptions = ref<number[]>([5, 10, 15, 20])
-const totalRecords = ref<number>(20)
+const totalRecords = ref<number>(0)
 const loading = ref<boolean>(false)
 const authStore = useAuthStore()
 
@@ -31,7 +33,7 @@ const user = computed(() => {
 const getRecordsService = async (): Promise<void> => {
   try {
     loading.value = true
-    const res = await getRecords(user.value.id, page.value, limit.value, {})
+    const res = await getRecords(user.value.id, page.value, limit.value, sortField.value, sortOrder.value, {})
     const formattedRecords: FormatRecord[] = res.records.map((record: Record) => {
       return {
         ...record,
@@ -80,6 +82,7 @@ const deleteRecordApi = async (): Promise<void> => {
   deleteRecordDialog.value = false
   selectedRecord.value = null
 }
+
 const handlePageChange = async (event): Promise<void> => {
   if (page.value !== event.page || limit.value !== event.rows) {
     page.value = event.page
@@ -87,6 +90,11 @@ const handlePageChange = async (event): Promise<void> => {
     await getRecordsService()
   }
 }
+const onSort = async(event): Promise<void> => {
+  sortField.value = event.sortField;
+  sortOrder.value = event.sortOrder === 1 ? 1 : -1;
+  await getRecordsService();
+};
 </script>
 
 <template>
@@ -105,6 +113,9 @@ const handlePageChange = async (event): Promise<void> => {
       tableStyle="min-width: 50rem"
       dataKey="_id"
       :onPage="handlePageChange"
+      :sortField="sortField"
+      :sortOrder="sortOrder"
+      @sort="onSort"
     >
       <template #header>
         <div class="flex justify-content-between">


### PR DESCRIPTION
Completed Tasks:

* Add a User Records View to show the records in a DataTable component from primeVue.
* Create services  for user records and consume it from backend:
  * getRecords: Service to get the records, add pagination, and add ascendent ordescendent sorting.
  * deleteRecord: Service to delete a record by id (soft deleted).
* Add a dialog confirm when  deleting a specific record.
* Add Interfaces for Records: 
  * **Record**:  Record got from the Backend response.
   * **FormatRecord**: Record used in the Frontend with the created_at formated as a string.
   * **Records**: Records got from the Backend response.
* Create a  `utils` folder  and add a `formatDate.js` file to format a Date to localeString.
* Create a debounce input using lodash to search by amount, user_balance, and operation_response fields.
* Implement the logic to clear the search typed by the user.
* Add delete and clear buttons.
* Format code.


Dependencies installed:
* lodash.debounce v4.0.8: https://www.npmjs.com/package/lodash.debounce