### PR TITLE
refactor: Change UserRecords view to improve dataTable display

### DIFF
--- a/src/interfaces/Record.ts
+++ b/src/interfaces/Record.ts
@@ -1,7 +1,7 @@
 export interface Record {
   _id: string
-  operation_id: string
-  user_id: string
+  operation_type: string
+  user_username: string
   amount: string
   user_balance: string
   operation_response: string
@@ -11,14 +11,14 @@ export interface Record {
 }
 export interface FormatRecord {
   _id: string
-  operation_id: string
-  user_id: string
+  operation_type: string
+  user_username: string
   amount: string
   user_balance: string
   operation_response: string
   is_deleted: boolean
   created_at: String
-  updated_at: Date
+  updated_at: String
 }
 export interface Records {
   records: Record[]

--- a/src/views/UserRecords.vue
+++ b/src/views/UserRecords.vue
@@ -47,7 +47,8 @@ const getRecordsService = async (): Promise<void> => {
     const formattedRecords: FormatRecord[] = res.records.map((record: Record) => {
       return {
         ...record,
-        created_at: formatDate(record.created_at)
+        created_at: formatDate(record.created_at),
+        updated_at: formatDate(record.updated_at)
       }
     })
     records.value = formattedRecords
@@ -174,8 +175,8 @@ const clearSearchText = (): void => {
       <template #empty> No records found </template>
       <Column selectionMode="single" headerStyle="width: 3rem" class="text-center"></Column>
       <Column field="_id" header="Id" sortable style="width: 5%"></Column>
-      <Column field="operation_id" header="Operation Id" sortable style="width: 15%"></Column>
-      <Column field="user_id" header="User Id" sortable style="width: 15%"></Column>
+      <Column field="operation_type" header="Operation Type" sortable style="width: 15%"></Column>
+      <Column field="user_username" header="User email" sortable style="width: 15%"></Column>
       <Column field="amount" header="Amount" sortable style="width: 10%"></Column>
       <Column field="user_balance" header="User Balance" sortable style="width: 10%"></Column>
       <Column
@@ -185,6 +186,7 @@ const clearSearchText = (): void => {
         style="width: 15%"
       ></Column>
       <Column field="created_at" header="Created At" sortable style="width: 15%"></Column>
+      <Column field="updated_at" header="Updated At" sortable style="width: 15%"></Column>
     </DataTable>
   </div>
   <Dialog


### PR DESCRIPTION
Completed Tasks:
* Refactor `Record` interface to get operation_type and user_username from the Backend instead of operation_id and user_id.
* Refactor `FormatRecord` interface.
* Add a new column at the end of the Datatable component to display `the updated_at` date from a `Record` in the screen.